### PR TITLE
fix(redhat): Fixing the installation in RedHat

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -59,7 +59,3 @@ rabbitmq_plugins:
 # RabbitMQ cluster
 rabbitmq_clustering_enabled: false
 rabbitmq_erlang_cookie_file_path: "/var/lib/rabbitmq/.erlang.cookie"
-
-
-# RabbitMQ repositories on satellite
-rabbitmq_repository_on_satellite:

--- a/tasks/install.redhat.yml
+++ b/tasks/install.redhat.yml
@@ -3,13 +3,8 @@
   rhsm_repository:
     name: "{{ item }}"
     state: enabled
-  with_items: "{{ rabbitmq_repository_on_satellite }}"
+  loop: "{{ rabbitmq_repository_on_satellite }}"
   when: rabbitmq_repository_on_satellite is defined
-
-- name: install rabbitmq-server dependencies (RedHat)
-  yum: name="{{ item }}" state=present
-  with_items:
-    - libselinux-python
 
 - name: add erlang rpm key
   rpm_key:
@@ -24,26 +19,27 @@
     owner: root
     group: root
     mode: 0644
+  become: yes
   when: ansible_distribution != "RedHat"
 
-- name: install erlang
+- name: Install RabbitMQ dependencies
   yum:
-    name: erlang
-    state: present
+    name: "{{ item }}"
+    state: latest
+  loop:
+    - libselinux-python
+    - erlang
+    - socat
 
 - name: install rabbitmq-server {{ rabbitmq_version }} (RedHat)
   yum:
-    name: "https://dl.bintray.com/rabbitmq/all/rabbitmq-server/{{ rabbitmq_version }}/rabbitmq-server-{{ rabbitmq_version }}-1.el7.noarch.rpm"
+    name: >
+      {% if rabbitmq_repository_on_satellite is not defined %}
+      https://dl.bintray.com/rabbitmq/all/rabbitmq-server/{{ rabbitmq_version }}/rabbitmq-server-{{ rabbitmq_version }}-1.el7.noarch.rpm
+      {% else %}
+      rabbitmq-server-{{ rabbitmq_version }}
+      {% endif %}
     state: present
-  when: rabbitmq_repository_on_satellite is not defined
-
-
-- name: install rabbitmq-server {{ rabbitmq_version }} (RedHat)
-  yum:
-    name: "rabbitmq-server-{{ rabbitmq_version }}"
-    state: present
-  when: rabbitmq_repository_on_satellite is defined
-
 
 - name: enable rabbitmq-server to survive reboot
   service:


### PR DESCRIPTION
~First of all, I would like to thank you guys, **really** appreciated your work here, and even more for being a Brazilian company contributing with open source. Congratulations for this initiative! :+1:~ Nevermind (:

## Description
The role installation wasn't working in RedHat hosts, since it contains a conditional: `when: rabbitmq_repository_on_satellite is defined`, but it IS defined at [defaults](defaults/main.yml), then this conditional won't work.
Also changed the design, to be smaller and faster.

## Motivation and Context
At my first run, it didn't work as expected, since `rabbitmq_repository_on_satellite` IS defined by defaults (note that `rabbitmq_repository_on_satellite:` will define an empty variable, i.e.: `rabbitmq_repository_on_satellite=""`). So, I had to delete it and reorganize the task.

## How Has This Been Tested?
Using a CentOS 7 Vagrant box, and then at some EC2 instance for different enviroments (hmg/staging/production).

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
