### PR TITLE
Update cryptography to fix a CVE

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ click-completion==0.2.1
 colorama==0.3.7
 configparser==3.5.0
 cookiecutter==1.5.1
-cryptography==2.2.2
+cryptography==2.3.1
 enum34==1.1.6
 fasteners==0.14.1
 flake8==3.3.0


### PR DESCRIPTION
Update the `cryptography` package to version `2.3.1` to fix the CVE-2018-10903.
## Description
Updated `cryptography` in requirements.txt  from `2.2.2` to  `2.3.1` to fix the CVE-2018-10903.

## Motivation and Context
Fix the CVE-2018-10903, related to python-cryptography versions between >=1.9.0 and <2.3.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
