### PR TITLE
Feat/customize nodename

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ By default this role will install the currently last upstream version of RabbitM
           rabbitmq_patch: 9
 ```
 
-By default the role will try the configure the NODENAME with `rabbit@{{ansible_fqdn}}` when clustering is enabled, if you want to customize the node name, you can substitute the `ansible_fqdn` with the variable `rabbitmq_nodename`.
+By default the role will try the configure the NODENAME with `rabbit@{{ansible_fqdn}}` when clustering is enabled, if you want to customize the node name, you can substitute the NODENAME with the variables `rabbitmq_nodename_prefix`and `rabbitmq_nodename_hostname`.
 
 Others specific RabbitMQ environment variables can also be given.
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ None yet.
       roles:
         - stone-payments.rabbitmq
 ```
-By default this role will install the currently last upstream version of RabbitMQ (which is 3.7.4). If you want to install any other version you must give the version numbers.
+By default this role will install the currently last upstream version of RabbitMQ (which is 3.7.15). If you want to install any other version you must give the version numbers.
 
 ```yaml
     - hosts: servers
@@ -125,13 +125,14 @@ By default this role will install the currently last upstream version of RabbitM
           rabbitmq_patch: 9
 ```
 
-Specific RabbitMQ environment variables can also be given.
+By default the role will try the configure the NODENAME with `rabbit@{{ansible_fqdn}}` when clustering is enabled, if you want to customize the node name, you can substitute the `ansible_fqdn` with the variable `rabbitmq_nodename`.
+
+Others specific RabbitMQ environment variables can also be given.
 
 ```yaml
     vars:
       rabbitmq_conf_env:
         RABBITMQ_NODE_IP_ADDRESS: "127.0.0.2"
-        RABBITMQ_NODENAME: "nodename"
 ```
 
 You can alter: 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -61,9 +61,9 @@ rabbitmq_plugins:
 # RabbitMQ cluster
 rabbitmq_clustering_enabled: false
 rabbitmq_erlang_cookie_file_path: "/var/lib/rabbitmq/.erlang.cookie"
-
+rabbitmq_master_node_inventory_hostname: "{{rabbitmq_master_node}}"
+rabbitmq_nodename_prefix: rabbit
+rabbitmq_nodename_hostname: "{{ansible_fqdn}}"
 
 # RabbitMQ repositories on satellite
 rabbitmq_repository_on_satellite:
-rabbitmq_nodename_prefix: rabbit
-rabbitmq_nodename_hostname: "{{ansible_fqdn}}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -66,4 +66,4 @@ rabbitmq_erlang_cookie_file_path: "/var/lib/rabbitmq/.erlang.cookie"
 # RabbitMQ repositories on satellite
 rabbitmq_repository_on_satellite:
 rabbitmq_nodename_prefix: rabbit
-rabbitmq_nodename_hostname: ansible_fqdn
+rabbitmq_nodename_hostname: "{{ansible_fqdn}}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -65,3 +65,5 @@ rabbitmq_erlang_cookie_file_path: "/var/lib/rabbitmq/.erlang.cookie"
 
 # RabbitMQ repositories on satellite
 rabbitmq_repository_on_satellite:
+rabbitmq_nodename_prefix: rabbit
+rabbitmq_nodename_hostname: ansible_fqdn

--- a/tasks/clustering.yml
+++ b/tasks/clustering.yml
@@ -36,6 +36,7 @@
 
   when:
     - rabbitmq_clustering_enabled
+    - rabbitmq_master_node is defined
     - rabbitmq_master_node_inventory_hostname is defined
     - rabbitmq_erlang_cookie is defined
     - nodes_count.stdout|int < play_hosts|length

--- a/tasks/clustering.yml
+++ b/tasks/clustering.yml
@@ -21,21 +21,21 @@
 
   - name: stop rabbitmq app
     command: rabbitmqctl stop_app
-    when: "inventory_hostname != rabbitmq_master_node"
+    when: "inventory_hostname != rabbitmq_master_node_inventory_hostname"
 
   - name: join rabbitmq cluster
     command: rabbitmqctl join_cluster "rabbit@{{ rabbitmq_master_node }}"
     register: cluster_joined
-    when: "inventory_hostname != rabbitmq_master_node"
+    when: "inventory_hostname != rabbitmq_master_node_inventory_hostname"
     retries: 2
     delay: 1
 
   - name: start rabbitmq app
     command: rabbitmqctl start_app
-    when: "inventory_hostname != rabbitmq_master_node"
+    when: "inventory_hostname != rabbitmq_master_node_inventory_hostname"
 
   when:
     - rabbitmq_clustering_enabled
-    - rabbitmq_master_node is defined
+    - rabbitmq_master_node_inventory_hostname is defined
     - rabbitmq_erlang_cookie is defined
     - nodes_count.stdout|int < play_hosts|length

--- a/templates/rabbitmq-env.conf.j2
+++ b/templates/rabbitmq-env.conf.j2
@@ -1,4 +1,4 @@
 {% for variable,value in rabbitmq_conf_env.iteritems() %}
 {{ variable|upper() }}={{ value }}
 {% endfor %}
-NODENAME=rabbit@{{ inventory_hostname }}
+NODENAME={{ rabbitmq_nodename_prefix }}@{{ rabbitmq_nodename_hostname }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR enables the customisation of the nodenames of the RabbitMQ cluster.

## Motivation and Context
When using dynamic inventory with the Google Compute Engine plugin, you cannot customize the hostname of the inventory beyond the VM name, public_ip and private_ip. This limits the usage of the role because it uses the inventory_hostname as the NODENAME of the rabbitmq nodes. 

In GCP, the VM name is not enough to resolve it's DNS and the RabbitMQ Nodes need to be able to reach each other using it's NODENAMES. 

My proposal to fix theses issues and make it runnable on GCP requires two steps:
- Split the variable `rabbitmq_master_node` into two, one pointing to the actual FQDN that is reachable that is the `rabbitmq_master_node` and other that is just the inventory_hostname, to check if the running node is the master or one of the slaves `rabbitmq_master_node_inventory_hostname`.

- Make the NODENAME configurable with two variables, the `rabbitmq_nodename_prefix` and `rabbitmq_nodename_hostname`

I've also set good defaults, to make it more simple to use by someone outside GCP that does not have to deal with such burdens.

## How Has This Been Tested?
This role was executed multiple times in the environment described above.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
