### PR TITLE
Handle Bintray deprecation

### DIFF
--- a/files/rabbitmq.bintray.list
+++ b/files/rabbitmq.bintray.list
@@ -1,4 +1,0 @@
-deb https://dl.bintray.com/rabbitmq-erlang/debian bionic erlang
-deb https://dl.bintray.com/rabbitmq-erlang/debian xenial erlang
-deb https://dl.bintray.com/rabbitmq/debian bionic main
-deb https://dl.bintray.com/rabbitmq/debian xenial main

--- a/files/rabbitmq.launchpad.list
+++ b/files/rabbitmq.launchpad.list
@@ -1,0 +1,4 @@
+deb http://ppa.launchpad.net/rabbitmq/rabbitmq-erlang/ubuntu xenial main
+deb http://ppa.launchpad.net/rabbitmq/rabbitmq-erlang/ubuntu bionic main
+deb https://packagecloud.io/rabbitmq/rabbitmq-server/ubuntu/ bionic main
+deb https://packagecloud.io/rabbitmq/rabbitmq-server/ubuntu/ xenial main

--- a/tasks/install/ubuntu.yml
+++ b/tasks/install/ubuntu.yml
@@ -5,6 +5,20 @@
     state: present
   when: not rabbitmq_os_package
 
+  - name: Add rabbitmq repository's key
+  apt_key:
+    keyserver: "keyserver.ubuntu.com"
+    id: F77F1EDA57EBB1CC
+    state: present
+  when: not rabbitmq_os_package
+
+ - name: Add rabbitmq repository's key
+  apt_key:
+    keyserver: "keyserver.ubuntu.com"
+    id: F6609E60DC62814E
+    state: present
+  when: not rabbitmq_os_package
+
 - name: Add launchpad rabbitmq repository
   copy:
     src: rabbitmq.launchpad.list

--- a/tasks/install/ubuntu.yml
+++ b/tasks/install/ubuntu.yml
@@ -1,13 +1,13 @@
 ---
-- name: Add bintray rabbitmq repository's key
+- name: Add rabbitmq repository's key
   apt_key:
-    url: "https://bintray.com/user/downloadSubjectPublicKey?username=rabbitmq"
+    url: "https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc"
     state: present
   when: not rabbitmq_os_package
 
-- name: Add bintray rabbitmq repository
+- name: Add launchpad rabbitmq repository
   copy:
-    src: rabbitmq.bintray.list
+    src: rabbitmq.launchpad.list
     dest: /etc/apt/sources.list.d/
     backup: true
   when: not rabbitmq_os_package

--- a/tasks/install/ubuntu.yml
+++ b/tasks/install/ubuntu.yml
@@ -26,6 +26,15 @@
     backup: true
   when: not rabbitmq_os_package
 
+- name: Wait for dpkg locks
+  shell: while fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1; do sleep 1; done;
+  with_items:
+    - lock
+    - lock-frontend
+
+- name: Wait for apt lock
+  shell: while fuser /var/lib/apt/lists/lock >/dev/null 2>&1; do sleep 1; done;
+  
 - name: Install rabbitmq-server
   apt:
     name: rabbitmq-server={{ rabbitmq_package }}

--- a/tasks/install/ubuntu.yml
+++ b/tasks/install/ubuntu.yml
@@ -5,14 +5,14 @@
     state: present
   when: not rabbitmq_os_package
 
-  - name: Add rabbitmq repository's key
+- name: Add rabbitmq repository's key
   apt_key:
     keyserver: "keyserver.ubuntu.com"
     id: F77F1EDA57EBB1CC
     state: present
   when: not rabbitmq_os_package
 
- - name: Add rabbitmq repository's key
+- name: Add rabbitmq repository's key
   apt_key:
     keyserver: "keyserver.ubuntu.com"
     id: F6609E60DC62814E


### PR DESCRIPTION
## Description
Removing Bintray as it is going to die on May 1st.

## Motivation and Context
Bintray is no longer supported. Bintray went down yesterday and we couldn't create an AMI anymore as we were getting Forbidden IP errors on the RabbitMQ installation in Ansible.

https://status.bintray.com/incidents/x1dvhtdqkcnx

https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/

## How Has This Been Tested?
Changed for launchpad ppa & package cloud repository. Pointed our RabbitMQ cluster on my fork and booted new nodes. Worked perfectly

Feel free to edit as you want. 
