### PR TITLE
Ensure that users are not exposed + explicit permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,14 +99,31 @@ For RedHat machines make sure the machines are subscribed. Also, this role requi
 
   # RabbitMQ Users
   rabbitmq_manage_users: true
-
-  # The same format of the rabbitmq_users_default variable.
   # The management UI requires authentication and authorisation. For more details see: https://www.rabbitmq.com/management.html#permissions
-  rabbitmq_users: {}
-  rabbitmq_users_default:
-    admin:
-      password: rabbitmq
-      tags: administrator
+  # User has no permissions by default. vhost, write_priv, read_priv and configure_priv are ignored when permissions list is defined.
+  rabbitmq_users: []
+    # Single vhost permissions
+    # - user: "{{ vault_rabbitmq_user1_username }}"
+    #   password: "{{ vault_rabbitmq_user1_password }}"
+    #   vhost: somevhost # (Optional) vhost to apply access privileges. Default: "/".
+    #   read_priv: .*
+    #   write_priv: .*
+    #   configure_priv: .*
+    #   tags: administrator
+
+    # Multiple vhost permissions
+    # - user: "{{ vault_rabbitmq_admin_username }}"
+    #   password: "{{ vault_rabbitmq_admin_password }}"
+    #   permissions:
+    #     - vhost: "/"
+    #       configure_priv: .*
+    #       read_priv: .*
+    #       write_priv: .*
+    #     - vhost: "anothervhost"
+    #       configure_priv: .*
+    #       read_priv: .*
+    #       write_priv: .*
+    #   tags: administrator
 
   # RabbitMQ Vhosts
   rabbitmq_manage_vhosts: false  # (true | false) to manage VHosts

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -67,13 +67,33 @@ rabbitmq_plugins:
   - name: rabbitmq_shovel_management
     state: enabled
 
-# RabbitMQ Users
-rabbitmq_manage_users: true
-rabbitmq_users: {}
-rabbitmq_users_default:
-  admin:
-    password: rabbitmq
-    tags: administrator
+  # RabbitMQ Users
+  rabbitmq_manage_users: true
+  # The management UI requires authentication and authorisation. For more details see: https://www.rabbitmq.com/management.html#permissions
+  # User has no permissions by default. vhost, write_priv, read_priv and configure_priv are ignored when permissions list is defined.
+  rabbitmq_users: []
+    # Single vhost permissions
+    # - user: "{{ vault_rabbitmq_user1_username }}"
+    #   password: "{{ vault_rabbitmq_user1_password }}"
+    #   vhost: somevhost # (Optional) vhost to apply access privileges. Default: "/".
+    #   read_priv: .*
+    #   write_priv: .*
+    #   configure_priv: .*
+    #   tags: administrator
+
+    # Multiple vhost permissions
+    # - user: "{{ vault_rabbitmq_admin_username }}"
+    #   password: "{{ vault_rabbitmq_admin_password }}"
+    #   permissions:
+    #     - vhost: "/"
+    #       configure_priv: .*
+    #       read_priv: .*
+    #       write_priv: .*
+    #     - vhost: "anothervhost"
+    #       configure_priv: .*
+    #       read_priv: .*
+    #       write_priv: .*
+    #   tags: administrator
 
 # RabbitMQ Rest API Login Credentials
 rabbitmq_api_login_credentials: {}

--- a/tasks/config/users.yml
+++ b/tasks/config/users.yml
@@ -1,24 +1,9 @@
 ---
-- name: Creates rabbitmq_users_list fact
-  set_fact:
-    rabbitmq_users_list: {}
-
 - name: Ensure that rabbitmq guest user is removed
   rabbitmq_user:
     user: guest
     state: absent
   no_log: true
-
-- name: Combine rabbitmq_users_default with rabbitmq_users
-  set_fact:
-    rabbitmq_users_list: "{{ rabbitmq_users_default | default({}, true) | combine(rabbitmq_users | default({}, true), recursive=True) }}"
-
-# WITCHCRAFT: convert a list into a dict using a specific value as key and the whole list as value
-# - set_fact:
-#     rabbitmq_users_list: "{{ rabbitmq_users_list | default({}) | combine({ item.user: item }, recursive=True) }}"
-#   with_items:
-#     - "{{ rabbitmq_users_default }}"
-#     - "{{ rabbitmq_users | default([]) }}"
 
 - name: Show users to be processed
   debug:
@@ -27,14 +12,15 @@
 
 - name: Create RabbitMQ users
   rabbitmq_user:
-    user: "{{ item.key }}"
-    password: "{{ item.value.password }}"
-    vhost: "{{ item.value.vhost | default (omit) }}"
-    configure_priv: "{{ item.value.configure_priv | default('.*') }}"
-    read_priv: "{{ item.value.read_priv | default('.*') }}"
-    write_priv: "{{ item.value.write_priv | default('.*') }}"
-    tags: "{{ item.value.tags | default(omit) }}"
-    state: "{{ item.value.state | default('present') }}"
-    update_password: "{{ item.value.update_password | default('always') }}"
+    user: "{{ item.user }}"
+    password: "{{ item.password }}"
+    vhost: "{{ item.vhost | default (omit) }}"
+    permissions: "{{ item.permissions | default(omit) }}"
+    configure_priv: "{{ item.configure_priv | default(omit) }}"
+    read_priv: "{{ item.read_priv | default(omit) }}"
+    write_priv: "{{ item.write_priv | default(omit) }}"
+    tags: "{{ item.tags | default(omit) }}"
+    state: "{{ item.state | default('present') }}"
+    update_password: "{{ item.update_password | default('always') }}"
   no_log: true
-  with_dict: "{{ rabbitmq_users_list }}"
+  loop: "{{ rabbitmq_users }}"


### PR DESCRIPTION
## Description

1. ensure that no user are exposed on code.
The rabbitmq_users variable was converted to an list, so the project could define usernames and passwords into vault. (username was an dict key)
rabbitmq_users_default was removed as it could be changed by de project, making no sense to exist.

2. ensure that all permissions are explicitly defined by the project

## Motivation and Context
1. Admin username is exposed on code
2. If the project doesn't change Admin password, the same will be exposed on code. (It happens)
3. Users permissions should not have all permissions allowed by default.
4. Users permissions should be explicitly defined by the project to avoid users with undesired access.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
