### PR TITLE
Ensure that the plugins list is respected

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,12 +90,9 @@ For RedHat machines make sure the machines are subscribed. Also, this role requi
   rabbitmq_sbin_path: /usr/lib/rabbitmq/sbin
   rabbitmq_plugins_prefix_path: /usr/lib/rabbitmq
   rabbitmq_plugins:
-    - name: rabbitmq_management
-      state: enabled
-    - name: rabbitmq_shovel
-      state: enabled
-    - name: rabbitmq_shovel_management
-      state: enabled
+    - rabbitmq_management
+    - rabbitmq_shovel
+    - rabbitmq_shovel_management
 
   # RabbitMQ Users
   rabbitmq_manage_users: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -60,12 +60,9 @@ rabbitmq_bin_path: /usr/lib/rabbitmq/bin
 rabbitmq_sbin_path: /usr/lib/rabbitmq/sbin
 rabbitmq_plugins_prefix_path: /usr/lib/rabbitmq
 rabbitmq_plugins:
-  - name: rabbitmq_management
-    state: enabled
-  - name: rabbitmq_shovel
-    state: enabled
-  - name: rabbitmq_shovel_management
-    state: enabled
+  - rabbitmq_management
+  - rabbitmq_shovel
+  - rabbitmq_shovel_management
 
 # RabbitMQ Users
 rabbitmq_manage_users: true

--- a/tasks/config/plugins.yml
+++ b/tasks/config/plugins.yml
@@ -1,18 +1,11 @@
 ---
-- name: Get RabbitMQ installed plugins
-  command: rabbitmq-plugins list -e -m
-  changed_when: false
-  register: rabbitmq_installed_plugins
-
 - name: Enable plugins
   rabbitmq_plugin:
-    names: "{{ item.name }}"
-    state: "{{ item.state }}"
-  with_items: "{{ rabbitmq_plugins }}"
+    names: "{{ rabbitmq_plugins | join(',') }}"
+    state: enabled
+    new_only: no # ensure that plugins that are not on list will be disabled.
   when:
     - rabbitmq_plugins | length > 0
-    - rabbitmq_installed_plugins.stdout_lines is defined
-    - item.name not in rabbitmq_installed_plugins.stdout_lines
 
 - name: Force to correct enabled plugins permissions
   file:


### PR DESCRIPTION
## Description
1. fix the plugins setup, ensuring that the plugins list is respected.
The plugin list was simplified, and the code is respecting the plugins on the list.
If the plugin is removed from the list, it will be disabled from the server.
2. we don't need to check if the plugin is installed, the module is idempotent.

## Motivation and Context
1. rabbitmq_plugin module expect a single entry as enabled plugins.
2. if we iterate over plugins, only the last plugin in the list will be enabled at the end.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
