### PR TITLE
Ensure plugin setup and remove initial credentials from code

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,14 +99,31 @@ For RedHat machines make sure the machines are subscribed. Also, this role requi
 
   # RabbitMQ Users
   rabbitmq_manage_users: true
-
-  # The same format of the rabbitmq_users_default variable.
   # The management UI requires authentication and authorisation. For more details see: https://www.rabbitmq.com/management.html#permissions
-  rabbitmq_users: {}
-  rabbitmq_users_default:
-    admin:
-      password: rabbitmq
-      tags: administrator
+  # User has no permissions by default. vhost, write_priv, read_priv and configure_priv are ignored when permissions list is defined.
+  rabbitmq_users: []
+    # Single vhost permissions
+    # - user: "{{ vault_rabbitmq_user1_username }}"
+    #   password: "{{ vault_rabbitmq_user1_password }}"
+    #   vhost: somevhost # (Optional) vhost to apply access privileges. Default: "/".
+    #   read_priv: .*
+    #   write_priv: .*
+    #   configure_priv: .*
+    #   tags: administrator
+
+    # Multiple vhost permissions
+    # - user: "{{ vault_rabbitmq_admin_username }}"
+    #   password: "{{ vault_rabbitmq_admin_password }}"
+    #   permissions:
+    #     - vhost: "/"
+    #       configure_priv: .*
+    #       read_priv: .*
+    #       write_priv: .*
+    #     - vhost: "anothervhost"
+    #       configure_priv: .*
+    #       read_priv: .*
+    #       write_priv: .*
+    #   tags: administrator
 
   # RabbitMQ Vhosts
   rabbitmq_manage_vhosts: false  # (true | false) to manage VHosts

--- a/README.md
+++ b/README.md
@@ -90,12 +90,9 @@ For RedHat machines make sure the machines are subscribed. Also, this role requi
   rabbitmq_sbin_path: /usr/lib/rabbitmq/sbin
   rabbitmq_plugins_prefix_path: /usr/lib/rabbitmq
   rabbitmq_plugins:
-    - name: rabbitmq_management
-      state: enabled
-    - name: rabbitmq_shovel
-      state: enabled
-    - name: rabbitmq_shovel_management
-      state: enabled
+    - rabbitmq_management
+    - rabbitmq_shovel
+    - rabbitmq_shovel_management
 
   # RabbitMQ Users
   rabbitmq_manage_users: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -60,12 +60,9 @@ rabbitmq_bin_path: /usr/lib/rabbitmq/bin
 rabbitmq_sbin_path: /usr/lib/rabbitmq/sbin
 rabbitmq_plugins_prefix_path: /usr/lib/rabbitmq
 rabbitmq_plugins:
-  - name: rabbitmq_management
-    state: enabled
-  - name: rabbitmq_shovel
-    state: enabled
-  - name: rabbitmq_shovel_management
-    state: enabled
+  - rabbitmq_management
+  - rabbitmq_shovel
+  - rabbitmq_shovel_management
 
   # RabbitMQ Users
   rabbitmq_manage_users: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -64,33 +64,33 @@ rabbitmq_plugins:
   - rabbitmq_shovel
   - rabbitmq_shovel_management
 
-  # RabbitMQ Users
-  rabbitmq_manage_users: true
-  # The management UI requires authentication and authorisation. For more details see: https://www.rabbitmq.com/management.html#permissions
-  # User has no permissions by default. vhost, write_priv, read_priv and configure_priv are ignored when permissions list is defined.
-  rabbitmq_users: []
-    # Single vhost permissions
-    # - user: "{{ vault_rabbitmq_user1_username }}"
-    #   password: "{{ vault_rabbitmq_user1_password }}"
-    #   vhost: somevhost # (Optional) vhost to apply access privileges. Default: "/".
-    #   read_priv: .*
-    #   write_priv: .*
-    #   configure_priv: .*
-    #   tags: administrator
+# RabbitMQ Users
+rabbitmq_manage_users: true
+# The management UI requires authentication and authorisation. For more details see: https://www.rabbitmq.com/management.html#permissions
+# User has no permissions by default. vhost, write_priv, read_priv and configure_priv are ignored when permissions list is defined.
+rabbitmq_users: []
+# Single vhost permissions
+# - user: "{{ vault_rabbitmq_user1_username }}"
+#   password: "{{ vault_rabbitmq_user1_password }}"
+#   vhost: somevhost # (Optional) vhost to apply access privileges. Default: "/".
+#   read_priv: .*
+#   write_priv: .*
+#   configure_priv: .*
+#   tags: administrator
 
-    # Multiple vhost permissions
-    # - user: "{{ vault_rabbitmq_admin_username }}"
-    #   password: "{{ vault_rabbitmq_admin_password }}"
-    #   permissions:
-    #     - vhost: "/"
-    #       configure_priv: .*
-    #       read_priv: .*
-    #       write_priv: .*
-    #     - vhost: "anothervhost"
-    #       configure_priv: .*
-    #       read_priv: .*
-    #       write_priv: .*
-    #   tags: administrator
+# Multiple vhost permissions
+# - user: "{{ vault_rabbitmq_admin_username }}"
+#   password: "{{ vault_rabbitmq_admin_password }}"
+#   permissions:
+#     - vhost: "/"
+#       configure_priv: .*
+#       read_priv: .*
+#       write_priv: .*
+#     - vhost: "anothervhost"
+#       configure_priv: .*
+#       read_priv: .*
+#       write_priv: .*
+#   tags: administrator
 
 # RabbitMQ Rest API Login Credentials
 rabbitmq_api_login_credentials: {}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -67,13 +67,33 @@ rabbitmq_plugins:
   - name: rabbitmq_shovel_management
     state: enabled
 
-# RabbitMQ Users
-rabbitmq_manage_users: true
-rabbitmq_users: {}
-rabbitmq_users_default:
-  admin:
-    password: rabbitmq
-    tags: administrator
+  # RabbitMQ Users
+  rabbitmq_manage_users: true
+  # The management UI requires authentication and authorisation. For more details see: https://www.rabbitmq.com/management.html#permissions
+  # User has no permissions by default. vhost, write_priv, read_priv and configure_priv are ignored when permissions list is defined.
+  rabbitmq_users: []
+    # Single vhost permissions
+    # - user: "{{ vault_rabbitmq_user1_username }}"
+    #   password: "{{ vault_rabbitmq_user1_password }}"
+    #   vhost: somevhost # (Optional) vhost to apply access privileges. Default: "/".
+    #   read_priv: .*
+    #   write_priv: .*
+    #   configure_priv: .*
+    #   tags: administrator
+
+    # Multiple vhost permissions
+    # - user: "{{ vault_rabbitmq_admin_username }}"
+    #   password: "{{ vault_rabbitmq_admin_password }}"
+    #   permissions:
+    #     - vhost: "/"
+    #       configure_priv: .*
+    #       read_priv: .*
+    #       write_priv: .*
+    #     - vhost: "anothervhost"
+    #       configure_priv: .*
+    #       read_priv: .*
+    #       write_priv: .*
+    #   tags: administrator
 
 # RabbitMQ Rest API Login Credentials
 rabbitmq_api_login_credentials: {}

--- a/tasks/config/bindings.yml
+++ b/tasks/config/bindings.yml
@@ -18,3 +18,5 @@
     durable: "{{ binding_item.value.durable | default(omit) }}"
     internal: "{{ binding_item.value.internal | default(omit) }}"
     state: "{{ binding_item.value.state | default(omit) }}"
+  delegate_to: localhost
+  become: false

--- a/tasks/config/exchanges.yml
+++ b/tasks/config/exchanges.yml
@@ -17,3 +17,5 @@
     durable: "{{ exchange_item.value.durable | default(omit) }}"
     internal: "{{ exchange_item.value.internal | default(omit) }}"
     state: "{{ exchange_item.value.state | default(omit) }}"
+  delegate_to: localhost
+  become: false

--- a/tasks/config/plugins.yml
+++ b/tasks/config/plugins.yml
@@ -1,18 +1,11 @@
 ---
-- name: Get RabbitMQ installed plugins
-  command: rabbitmq-plugins list -e -m
-  changed_when: false
-  register: rabbitmq_installed_plugins
-
 - name: Enable plugins
   rabbitmq_plugin:
-    names: "{{ item.name }}"
-    state: "{{ item.state }}"
-  with_items: "{{ rabbitmq_plugins }}"
+    names: "{{ rabbitmq_plugins | join(',') }}"
+    state: enabled
+    new_only: no # ensure that plugins that are not on list will be disabled.
   when:
     - rabbitmq_plugins | length > 0
-    - rabbitmq_installed_plugins.stdout_lines is defined
-    - item.name not in rabbitmq_installed_plugins.stdout_lines
 
 - name: Force to correct enabled plugins permissions
   file:

--- a/tasks/config/queues.yml
+++ b/tasks/config/queues.yml
@@ -21,3 +21,5 @@
     message_ttl: "{{ queue_item.value.message_ttl | default(omit) }}"
     arguments: "{{ queue_item.value.arguments | default(omit) }}"
     state: "{{ queue_item.value.state | default(omit) }}"
+  delegate_to: localhost
+  become: false

--- a/tasks/config/users.yml
+++ b/tasks/config/users.yml
@@ -1,24 +1,9 @@
 ---
-- name: Creates rabbitmq_users_list fact
-  set_fact:
-    rabbitmq_users_list: {}
-
 - name: Ensure that rabbitmq guest user is removed
   rabbitmq_user:
     user: guest
     state: absent
   no_log: true
-
-- name: Combine rabbitmq_users_default with rabbitmq_users
-  set_fact:
-    rabbitmq_users_list: "{{ rabbitmq_users_default | default({}, true) | combine(rabbitmq_users | default({}, true), recursive=True) }}"
-
-# WITCHCRAFT: convert a list into a dict using a specific value as key and the whole list as value
-# - set_fact:
-#     rabbitmq_users_list: "{{ rabbitmq_users_list | default({}) | combine({ item.user: item }, recursive=True) }}"
-#   with_items:
-#     - "{{ rabbitmq_users_default }}"
-#     - "{{ rabbitmq_users | default([]) }}"
 
 - name: Show users to be processed
   debug:
@@ -27,14 +12,15 @@
 
 - name: Create RabbitMQ users
   rabbitmq_user:
-    user: "{{ item.key }}"
-    password: "{{ item.value.password }}"
-    vhost: "{{ item.value.vhost | default (omit) }}"
-    configure_priv: "{{ item.value.configure_priv | default('.*') }}"
-    read_priv: "{{ item.value.read_priv | default('.*') }}"
-    write_priv: "{{ item.value.write_priv | default('.*') }}"
-    tags: "{{ item.value.tags | default(omit) }}"
-    state: "{{ item.value.state | default('present') }}"
-    update_password: "{{ item.value.update_password | default('always') }}"
+    user: "{{ item.user }}"
+    password: "{{ item.password }}"
+    vhost: "{{ item.vhost | default (omit) }}"
+    permissions: "{{ item.permissions | default(omit) }}"
+    configure_priv: "{{ item.configure_priv | default(omit) }}"
+    read_priv: "{{ item.read_priv | default(omit) }}"
+    write_priv: "{{ item.write_priv | default(omit) }}"
+    tags: "{{ item.tags | default(omit) }}"
+    state: "{{ item.state | default('present') }}"
+    update_password: "{{ item.update_password | default('always') }}"
   no_log: true
-  with_dict: "{{ rabbitmq_users_list }}"
+  loop: "{{ rabbitmq_users }}"

--- a/tasks/config/users.yml
+++ b/tasks/config/users.yml
@@ -5,11 +5,6 @@
     state: absent
   no_log: true
 
-- name: Show users to be processed
-  debug:
-    msg: "{{ rabbitmq_users_list }}"
-    verbosity: 2
-
 - name: Create RabbitMQ users
   rabbitmq_user:
     user: "{{ item.user }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,6 +29,12 @@
   tags: rabbitmq_vhosts
   run_once: true
 
+- name: Tasks to manage RabbitMQ Users
+  include_tasks: config/users.yml
+  when: rabbitmq_manage_users
+  tags: rabbitmq_users
+  run_once: true
+
 - name: Tasks to manage RabbitMQ Queues
   include_tasks: config/queues.yml
   when: rabbitmq_manage_queues
@@ -54,12 +60,6 @@
   loop_control:
     loop_var: binding_item
   tags: rabbitmq_bindings
-  run_once: true
-
-- name: Tasks to manage RabbitMQ Users
-  include_tasks: config/users.yml
-  when: rabbitmq_manage_users
-  tags: rabbitmq_users
   run_once: true
 
 - name: Tasks to manage RabbitMQ Policies


### PR DESCRIPTION
## Description
This PR:
1. ensure plugin setup respect the list
2. remove initial credentials from code

## Motivation and Context
1. Credentials are not supposed to be in code.
2. Simplifies the plugin list. If the plugin is in the list, the role ensures that the plugin will be installed. If the plugin is not in the list, the role will ensure that the plugin is uninstalled. This make the code cleaner. This is the breaking change.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
