### PR TITLE
Use Official repositores instead of Bintray

### DIFF
--- a/files/rabbitmq.bintray.list
+++ b/files/rabbitmq.bintray.list
@@ -1,4 +1,0 @@
-deb https://dl.bintray.com/rabbitmq-erlang/debian bionic erlang
-deb https://dl.bintray.com/rabbitmq-erlang/debian xenial erlang
-deb https://dl.bintray.com/rabbitmq/debian bionic main
-deb https://dl.bintray.com/rabbitmq/debian xenial main

--- a/files/rabbitmq.list
+++ b/files/rabbitmq.list
@@ -1,2 +1,16 @@
 # Official repository of rabbitmq
-deb http://www.rabbitmq.com/debian/ testing main
+## https://www.rabbitmq.com/install-debian.html#apt-quick-start-packagecloud
+
+## Provides modern Erlang/OTP releases
+##
+## "bionic" as distribution name should work for any reasonably recent Ubuntu or Debian release.
+## See the release to distribution mapping table in RabbitMQ doc guides to learn more.
+deb http://ppa.launchpad.net/rabbitmq/rabbitmq-erlang/ubuntu bionic main
+deb-src http://ppa.launchpad.net/rabbitmq/rabbitmq-erlang/ubuntu bionic main
+
+## Provides RabbitMQ
+##
+## "bionic" as distribution name should work for any reasonably recent Ubuntu or Debian release.
+## See the release to distribution mapping table in RabbitMQ doc guides to learn more.
+deb https://packagecloud.io/rabbitmq/rabbitmq-server/ubuntu/ bionic main
+deb-src https://packagecloud.io/rabbitmq/rabbitmq-server/ubuntu/ bionic main

--- a/tasks/install/ubuntu.yml
+++ b/tasks/install/ubuntu.yml
@@ -1,13 +1,20 @@
 ---
-- name: Add bintray rabbitmq repository's key
+- name: Add the official Erlang repository's key
   apt_key:
-    url: "https://bintray.com/user/downloadSubjectPublicKey?username=rabbitmq"
+    url: "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xf77f1eda57ebb1cc"
     state: present
   when: not rabbitmq_os_package
 
+- name: Add the PackageCloud RabbitMQ repository's key
+  apt_key:
+    url: "https://packagecloud.io/rabbitmq/rabbitmq-server/gpgkey"
+    state: present
+  when: not rabbitmq_os_package
+  
+
 - name: Add bintray rabbitmq repository
   copy:
-    src: rabbitmq.bintray.list
+    src: rabbitmq.list
     dest: /etc/apt/sources.list.d/
     backup: true
   when: not rabbitmq_os_package
@@ -15,9 +22,9 @@
 - name: Install rabbitmq-server
   apt:
     name: rabbitmq-server={{ rabbitmq_package }}
-    update_cache: true
+    update_cache: yes
     state: present
-    force: true
+    force: yes
 
 - name: Update locale
   command: update-locale LC_ALL=en_US.UTF-8

--- a/templates/rabbitmq.conf.j2
+++ b/templates/rabbitmq.conf.j2
@@ -7,7 +7,7 @@
 
 ## Networking
 ## ====================
-listeners.tcp.default = {{ rabbitmq_conf_tcp_listeners_address ~ ":" if rabbitmq_conf_tcp_listeners_address is defined and rabbitmq_conf_tcp_listeners_address|ipaddr else ":::" }}{{ rabbitmq_conf_tcp_listeners_port | default("5672")}}
+listeners.tcp.default = {{ rabbitmq_conf_tcp_listeners_address ~ ":" if rabbitmq_conf_tcp_listeners_address is defined and rabbitmq_conf_tcp_listeners_address|ansible.utils.ipaddr else ":::" }}{{ rabbitmq_conf_tcp_listeners_port | default("5672")}}
 num_acceptors.tcp = {{ rabbitmq_conf_num_acceptors_tcp | default("10")}}
 
 {% if rabbitmq_newrelic_agent_enabled %}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR replaces the old bintray APT repository with the current Official repos in the [RabbitMQ Documentation](https://www.rabbitmq.com/install-debian.html#apt-quick-start-packagecloud).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bintray is repositories are no longer working, so the roles are not working properly. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I have deployed to a server :)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
