### PR TITLE
allow multiple rhel release version id

### DIFF
--- a/tasks/install/redhat.yml
+++ b/tasks/install/redhat.yml
@@ -1,5 +1,5 @@
 ---
-- name: Subscribe to puppet repository on satellite.
+- name: Subscribe to the package repository
   rhsm_repository:
     name: "{{ item }}"
     state: enabled
@@ -45,14 +45,9 @@
         description: RabbitMQ-Server Repo
   when: rabbitmq_repository_on_satellite | length == 0
 
-- name: Install rabbitmq-server dependencies (RedHat)
-  yum:
-    name: libselinux-python
-    state: present
-
 - name: Install rabbitmq-server {{ rabbitmq_version }}
   yum:
-    name: "rabbitmq-server-{{ rabbitmq_package }}.el7.noarch"
+    name: "rabbitmq-server-{{ rabbitmq_package }}.el*.noarch"
     state: present
 
 - name: Ensure rabbitmq server is started and enabled


### PR DESCRIPTION
## Description
Removes the  OS release version_id from rhel setup.

## Motivation and Context
Setup on rhel8 family.

## How Has This Been Tested?
New installation on oraclelinux8 and centos7.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
