### PR TITLE
Removes default rhsm repo

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,10 +2,8 @@
 # Take the package given by the OS/distrib (Debian-like only)
 rabbitmq_os_package: false
 
-# RabbitMQ repositories in katello
-rabbitmq_repository_on_satellite:
-  - Stone_RabbitMQ_erlang_rhel7
-  - Stone_RabbitMQ_38_rhel7
+# RabbitMQ rhsm repositories
+rabbitmq_repository_on_satellite: []
 
 # Always install RabbitMQ,
 # unless it's already installed and you don't want it to be replaced


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Removes rhsm repos from `rabbitmq_repository_on_satellite`

## Motivation and Context
This is a public role. We should not set rhsm repos here.

## How Has This Been Tested?
Molecule

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
